### PR TITLE
Remove @overrides from modules.py

### DIFF
--- a/neuronlp2/nn/modules.py
+++ b/neuronlp2/nn/modules.py
@@ -1,6 +1,5 @@
 __author__ = 'max'
 
-from overrides import overrides
 from collections import OrderedDict
 import math
 import numpy as np
@@ -153,7 +152,6 @@ class BiAffine(nn.Module):
             output = output * mask_key.unsqueeze(1)
         return output
 
-    @overrides
     def extra_repr(self):
         s = '{key_dim}, {query_dim}'
         return s.format(**self.__dict__)


### PR DESCRIPTION
I have experienced an issue when trying to use the library with `PyTorch 1.10.0` caused by the `@overrides` operator, probably caused by the conflict of types annotation.

```
Traceback (most recent call last):
  File "ner.py", line 23, in <module>
    from neuronlp2.models import BiRecurrentConv, BiVarRecurrentConv, BiRecurrentConvCRF, BiVarRecurrentConvCRF
  File "/content/NeuroNLP2/neuronlp2/models/__init__.py", line 3, in <module>
    from neuronlp2.models.sequence_labeling import *
  File "/content/NeuroNLP2/neuronlp2/models/sequence_labeling.py", line 7, in <module>
    from neuronlp2.nn import ChainCRF, VarGRU, VarRNN, VarLSTM, VarFastLSTM, CharCNN
  File "/content/NeuroNLP2/neuronlp2/nn/__init__.py", line 4, in <module>
    from neuronlp2.nn.crf import ChainCRF, TreeCRF
  File "/content/NeuroNLP2/neuronlp2/nn/crf.py", line 7, in <module>
    from neuronlp2.nn.modules import BiAffine
  File "/content/NeuroNLP2/neuronlp2/nn/modules.py", line 82, in <module>
    class BiAffine(nn.Module):
  File "/content/NeuroNLP2/neuronlp2/nn/modules.py", line 156, in BiAffine
    @overrides
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 88, in overrides
    return _overrides(method, check_signature, check_at_runtime)
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 114, in _overrides
    _validate_method(method, super_class, check_signature)
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 135, in _validate_method
    ensure_signature_is_compatible(super_method, method, is_static)
  File "/usr/local/lib/python3.7/dist-packages/overrides/signature.py", line 93, in ensure_signature_is_compatible
    ensure_return_type_compatibility(super_type_hints, sub_type_hints, method_name)
  File "/usr/local/lib/python3.7/dist-packages/overrides/signature.py", line 288, in ensure_return_type_compatibility
    f"{method_name}: return type `{sub_return}` is not a `{super_return}`."
TypeError: BiAffine.extra_repr: return type `None` is not a `<class 'str'>`.
```

The possible solutions are to add `str` as a returned type to the `extra_repr` method. Hovewer, since no type annotation is used in the entire codebase I though it's better to remove the failing decorator since it has no significant effect anyway.